### PR TITLE
Use single CloudFormation object

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-square - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-square AWS CloudFormation management cli'
 url = 'https://github.com/KCOM-Enterprise/cfn-square'
-version = '0.2.6'
+version = '0.2.7'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -17,7 +17,7 @@ class StackActionHandler(object):
         self.logger = get_logger(root=True)
         self.config = config
         self.cfn = CloudFormation(region=self.config.region, dry_run=dry_run)
-        self.parameter_resolver = ParameterResolver(region=self.config.region)
+        self.parameter_resolver = ParameterResolver(self.cfn, region=self.config.region)
         self.cli_parameters = config.cli_params
 
     def execute_change_set(self):

--- a/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
@@ -3,7 +3,6 @@ from six import string_types
 from jmespath.exceptions import JMESPathError
 
 from cfn_sphere.file_loader import FileLoader
-from cfn_sphere.aws.cfn import CloudFormation
 from cfn_sphere.aws.ec2 import Ec2Api
 from cfn_sphere.aws.kms import KMS
 from cfn_sphere.aws.ssm import SSM
@@ -19,9 +18,9 @@ class ParameterResolver(object):
     Resolves a given artifact identifier to the value of a stacks output.
     """
 
-    def __init__(self, region="eu-west-1"):
+    def __init__(self, cfn, region="eu-west-1"):
         self.logger = get_logger()
-        self.cfn = CloudFormation(region)
+        self.cfn = cfn
         self.ec2 = Ec2Api(region)
         self.kms = KMS(region)
         self.ssm = SSM(region)

--- a/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
@@ -3,6 +3,7 @@ from six import string_types
 from jmespath.exceptions import JMESPathError
 
 from cfn_sphere.file_loader import FileLoader
+from cfn_sphere.aws.cfn import CloudFormation
 from cfn_sphere.aws.ec2 import Ec2Api
 from cfn_sphere.aws.kms import KMS
 from cfn_sphere.aws.ssm import SSM
@@ -17,8 +18,9 @@ class ParameterResolver(object):
     """
     Resolves a given artifact identifier to the value of a stacks output.
     """
+    DEFAULT_REGION = 'eu-west-1'
 
-    def __init__(self, cfn, region="eu-west-1"):
+    def __init__(self, cfn=CloudFormation(DEFAULT_REGION), region=DEFAULT_REGION):
         self.logger = get_logger()
         self.cfn = cfn
         self.ec2 = Ec2Api(region)

--- a/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
@@ -20,7 +20,7 @@ class ParameterResolver(object):
     """
     DEFAULT_REGION = 'eu-west-1'
 
-    def __init__(self, cfn=CloudFormation(DEFAULT_REGION), region=DEFAULT_REGION):
+    def __init__(self, cfn, region=DEFAULT_REGION):
         self.logger = get_logger()
         self.cfn = cfn
         self.ec2 = Ec2Api(region)

--- a/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
+++ b/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
@@ -10,7 +10,6 @@ except ImportError:
 from cfn_sphere.exceptions import CfnSphereException, CfnSphereBotoError
 from cfn_sphere.stack_configuration.parameter_resolver import ParameterResolver
 from cfn_sphere.transform import TransformDict
-from cfn_sphere.aws.cfn import CloudFormation
 
 class ParameterResolverTests(TestCase):
     def setUp(self):
@@ -20,8 +19,8 @@ class ParameterResolverTests(TestCase):
         self.ec2api_mock = self.ec2api_patcher.start()
         self.kms_mock = self.kms_patcher.start()
         self.ssm_mock = self.ssm_patcher.start()
-        self.cfn_mock2 = CloudFormation()
-        self.cfn_mock2.stack_exists = MagicMock(return_value = True)
+        self.cfn_mock = MagicMock();
+        self.cfn_mock.stack_exists = MagicMock(return_value = True)
 
     def tearDown(self):
         self.ec2api_patcher.stop()
@@ -45,31 +44,31 @@ class ParameterResolverTests(TestCase):
         stack_config = Mock()
         stack_config.parameters = TransformDict({'foo': ['a', 'b']}, {})
 
-        ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         convert_list_to_string_mock.assert_called_once_with(['a', 'b'])
 
     @patch('cfn_sphere.stack_configuration.parameter_resolver.ParameterResolver.get_output_value')
     def test_resolve_parameter_values_returns_ref_value(self, get_output_value_mock):
-        self.cfn_mock2.get_stacks_outputs = MagicMock(return_value = None)
+        self.cfn_mock.get_stacks_outputs = MagicMock(return_value = None)
         get_output_value_mock.return_value = 'bar'
 
         stack_config = Mock()
         stack_config.parameters = {'foo': '|Ref|stack.output'}
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
 
         get_output_value_mock.assert_called_with(None, "stack", "output")
         self.assertEqual({'foo': 'bar'}, result)
 
     @patch('cfn_sphere.stack_configuration.parameter_resolver.ParameterResolver.get_output_value')
     def test_resolve_parameter_values_returns_ref_list_value(self, get_output_value_mock):
-        self.cfn_mock2.get_stacks_outputs = MagicMock(return_value = None)
+        self.cfn_mock.get_stacks_outputs = MagicMock(return_value = None)
         get_output_value_mock.return_value = 'bar'
 
         stack_config = Mock()
         stack_config.parameters = TransformDict({'foo': ['|Ref|stack.output', '|Ref|stack.output']}, {})
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
 
         get_output_value_mock.assert_called_with(None, "stack", "output")
         self.assertEqual({'foo': 'bar,bar'}, result)
@@ -79,55 +78,55 @@ class ParameterResolverTests(TestCase):
         stack_config.parameters = {'foo': None}
 
         with self.assertRaises(CfnSphereException):
-            ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+            ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
 
     def test_resolve_parameter_values_returns_list_with_string_value(self):
         stack_config = Mock()
         stack_config.parameters = {'foo': "baa"}
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         self.assertEqual({'foo': 'baa'}, result)
 
     def test_resolve_parameter_values_returns_str_representation_of_false(self):
         stack_config = Mock()
         stack_config.parameters = {'foo': False}
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         self.assertEqual({'foo': 'false'}, result)
 
     def test_resolve_parameter_values_returns_str_representation_of_int(self):
         stack_config = Mock()
         stack_config.parameters = {'foo': 5}
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         self.assertEqual({'foo': '5'}, result)
 
     def test_resolve_parameter_values_returns_str_representation_of_float(self):
         stack_config = Mock()
         stack_config.parameters = {'foo': 5.555}
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         self.assertEqual({'foo': '5.555'}, result)
 
     def test_get_latest_value_returns_stacks_actual_value(self):
-        self.cfn_mock2.get_stack_parameters_dict = MagicMock(return_value = {'my-key': 'my-actual-value'})
-        
-        pr = ParameterResolver(self.cfn_mock2)
+        self.cfn_mock.get_stack_parameters_dict = MagicMock(return_value = {'my-key': 'my-actual-value'})
+
+        pr = ParameterResolver(self.cfn_mock)
         result = pr.get_latest_value('my-key', '|keepOrUse|default-value', 'my-stack')
 
-        self.cfn_mock2.get_stack_parameters_dict.assert_called_once_with('my-stack')
+        self.cfn_mock.get_stack_parameters_dict.assert_called_once_with('my-stack')
         self.assertEqual('my-actual-value', result)
 
     def test_get_latest_value_returns_default_value_called_once_with_stack(self):
-        self.cfn_mock2.get_stack_parameters_dict = MagicMock(return_value = {'not-my-key': 'my-actual-value'})
+        self.cfn_mock.get_stack_parameters_dict = MagicMock(return_value = {'not-my-key': 'my-actual-value'})
 
-        pr = ParameterResolver(self.cfn_mock2)
+        pr = ParameterResolver(self.cfn_mock)
         result = pr.get_latest_value('my-key', '|keepOrUse|default-value', 'my-stack')
 
-        self.cfn_mock2.get_stack_parameters_dict.assert_called_once_with('my-stack')
+        self.cfn_mock.get_stack_parameters_dict.assert_called_once_with('my-stack')
         self.assertEqual('default-value', result)
 
     def test_get_latest_value_raises_exception_on_error(self):
-        self.cfn_mock2.get_stack_parameters_dict = MagicMock(side_effect=Exception("foo"))
-        resolver = ParameterResolver(self.cfn_mock2)
+        self.cfn_mock.get_stack_parameters_dict = MagicMock(side_effect=Exception("foo"))
+        resolver = ParameterResolver(self.cfn_mock)
         with self.assertRaises(CfnSphereException):
             resolver.get_latest_value('my-key', '|keepOrUse|default-value', 'my-stack')
 
@@ -161,7 +160,7 @@ class ParameterResolverTests(TestCase):
 
     def test_handle_ssm_value_raises_exception_on_invalid_value_format(self):
         with self.assertRaises(CfnSphereException):
-            ParameterResolver(self.cfn_mock2).handle_ssm_value('|ssm|/test/|invalid')
+            ParameterResolver(self.cfn_mock).handle_ssm_value('|ssm|/test/|invalid')
 
     def test_resolve_parameter_values_returns_ssm_value(self):
         self.ssm_mock.return_value.get_parameter.return_value = "decryptedValue"
@@ -169,7 +168,7 @@ class ParameterResolverTests(TestCase):
         stack_config = Mock()
         stack_config.parameters = {'foo': '|ssm|/path/to/my/key'}
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         self.assertEqual(result, {'foo': 'decryptedValue'})
 
     def test_resolve_parameter_values_returns_decrypted_value(self):
@@ -178,23 +177,23 @@ class ParameterResolverTests(TestCase):
         stack_config = Mock()
         stack_config.parameters = {'foo': '|kms|encryptedValue'}
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
         self.assertEqual(result, {'foo': 'decryptedValue'})
 
     def test_update_parameters_with_cli_parameters_with_string_param_value(self):
-        result = ParameterResolver(self.cfn_mock2).update_parameters_with_cli_parameters(
+        result = ParameterResolver(self.cfn_mock).update_parameters_with_cli_parameters(
             parameters={'foo': "foo"}, cli_parameters={'stack1': {'foo': 'foobar'}}, stack_name='stack1')
         self.assertEqual({'foo': 'foobar'}, result)
 
     def test_update_parameters_with_cli_parameters_adds_new_cli_parameter(self):
-        result = ParameterResolver(self.cfn_mock2).update_parameters_with_cli_parameters(parameters={'foo': 'foo'},
+        result = ParameterResolver(self.cfn_mock).update_parameters_with_cli_parameters(parameters={'foo': 'foo'},
                                                                            cli_parameters={
                                                                                'stack1': {'moppel': 'foo'}},
                                                                            stack_name='stack1')
         self.assertDictEqual({'foo': 'foo', 'moppel': 'foo'}, result)
 
     def test_update_parameters_with_cli_parameters_with_string_param_value_for_several_stacks(self):
-        result = ParameterResolver(self.cfn_mock2).update_parameters_with_cli_parameters(
+        result = ParameterResolver(self.cfn_mock).update_parameters_with_cli_parameters(
             parameters={'foo': "foo"}, cli_parameters={'stack1': {'foo': 'foobar'}, 'stack2': {'foo': 'foofoo'}},
             stack_name='stack2')
         self.assertEqual({'foo': 'foofoo'}, result)
@@ -205,7 +204,7 @@ class ParameterResolverTests(TestCase):
         stack_config = Mock()
         stack_config.parameters = {'foo': "bar"}
 
-        result = ParameterResolver(self.cfn_mock2).resolve_parameter_values("stack1", stack_config, cli_parameters)
+        result = ParameterResolver(self.cfn_mock).resolve_parameter_values("stack1", stack_config, cli_parameters)
 
         self.assertEqual({'foo': 'foobar'}, result)
 
@@ -246,7 +245,7 @@ class ParameterResolverTests(TestCase):
 
 
 def test_update_parameters_with_cli_parameters_does_not_affect_other_stacks(self):
-    result = ParameterResolver(self.cfn_mock2).update_parameters_with_cli_parameters(
+    result = ParameterResolver(self.cfn_mock).update_parameters_with_cli_parameters(
         parameters={'foo': "foo"}, cli_parameters={'stack1': {'foo': 'foobar'}}, stack_name='stack2')
     self.assertEqual({'foo': 'foo'}, result)
 
@@ -258,5 +257,5 @@ def test_resolve_value_from_file(self, get_file_mock):
     stack_config = Mock()
     stack_config.parameters = {'foo': "|file|abc.txt"}
 
-    result = ParameterResolver(self.cfn_mock2).resolve_parameter_values('foo', stack_config)
+    result = ParameterResolver(self.cfn_mock).resolve_parameter_values('foo', stack_config)
     self.assertEqual({'foo': 'line1\nline2'}, result)


### PR DESCRIPTION
ParameterResolver was using a seperate CloudFormation object, as such clearing of the STACK_DESCRIPTIONS cache was taking place on a different object than that used to get the stack descriptions.

Fixed by passing the main instance of CloudFormation to the constructor of ParameterResolver.