### PR TITLE
AWS-377: Fix Travis CI

### DIFF
--- a/build.py
+++ b/build.py
@@ -32,7 +32,7 @@ def set_properties(project):
     project.depends_on('six')
     project.depends_on("click")
     project.depends_on("boto3", version=">=1.4.1")
-    project.depends_on("pyyaml")
+    project.depends_on("pyyaml", version="==3.13")
     project.depends_on("networkx")
     project.depends_on('prettytable')
     project.depends_on('gitpython')


### PR DESCRIPTION
Fixes Travis CI builds. Unit tests were failing due to a change in PyYAML behaviour. Example failure:
https://travis-ci.org/KCOM-Enterprise/cfn-square/jobs/538188503

This pins PyYAML to a version available when those tests were created.
