### PR TITLE
AWS-354: support SAM template packaging

### DIFF
--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -57,7 +57,8 @@ class StackActionHandler(object):
             else:
                 stack_policy = None
 
-            template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir)
+            template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir,
+                                                    self.config.region, stack_config.package_bucket)
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config, self.cli_parameters)
 
             stack = CloudFormationStack(template=template,
@@ -94,7 +95,8 @@ class StackActionHandler(object):
             else:
                 stack_policy = None
 
-            template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir)
+            template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir,
+                                                    self.config.region, stack_config.package_bucket)
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config, self.cli_parameters)
 
             stack = CloudFormationStack(template=template,

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -327,7 +327,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "Tags": stack.get_tags_list()
         }
@@ -361,7 +362,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "Tags": stack.get_tags_list()
         }
@@ -413,7 +415,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "ChangeSetName": stack.name + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(5)),
             "ChangeSetType": change_set_type

--- a/src/main/python/cfn_sphere/template/sam_packager.py
+++ b/src/main/python/cfn_sphere/template/sam_packager.py
@@ -1,0 +1,71 @@
+import json
+import os.path
+import subprocess
+import sys
+import tempfile
+
+import boto3
+
+from cfn_sphere.template import CloudFormationTemplate
+from cfn_sphere.util import get_logger
+
+class CloudFormationSamPackager:
+    """
+    Run `aws cloudformation package` to upload SAM package artifacts to S3 and
+    replace values in template.
+    """
+
+    @classmethod
+    def package(cls, template_url, working_dir, template, region, package_bucket):
+        logger = get_logger()
+
+        if not package_bucket:
+            return template
+
+        if template_url.lower().startswith("s3://") or  template_url.lower().startswith("https://"):
+            raise Exception("SAM packaging is only supported for local templates (not S3/HTTPS)")
+
+        template_body_dict = template.get_template_body_dict()
+
+        # Save template to a temporary file in the original template's
+        # directory. Call `aws cloudformation package` to upload artifacts
+        # to S3.
+        aws_credentials = boto3.DEFAULT_SESSION.get_credentials()
+        with tempfile.NamedTemporaryFile(mode="w",
+                                         dir=os.path.dirname(os.path.join(working_dir, template_url)),
+                                         suffix=".json") as src_fp:
+            # Save the template. Ensure the buffer's flushed to disk before
+            # calling `aws cloudformation package`.
+            json.dump(template_body_dict, src_fp)
+            src_fp.flush()
+
+            # Open temporary file for the packaged template.
+            # We'd previously used stdout, but the packaging process also
+            # wrote status to stdout when the source artifact changed, causing
+            # malformed JSON.
+            with tempfile.NamedTemporaryFile(mode="r") as dst_fp:
+                logger.info("Packaging {}".format(template_url))
+                result = subprocess.check_call(
+                    args=[
+                        "aws", "cloudformation", "package",
+                        "--template-file", src_fp.name,
+                        "--s3-bucket", package_bucket,
+                        "--output-template-file", dst_fp.name,
+                        "--use-json"
+                    ],
+                    env=dict(
+                        os.environ,
+                        AWS_REGION=region,
+                        AWS_ACCESS_KEY_ID=aws_credentials.access_key,
+                        AWS_SECRET_ACCESS_KEY=aws_credentials.secret_key,
+                        AWS_SESSION_TOKEN=aws_credentials.token
+                    ),
+                    stdout=subprocess.DEVNULL,
+                    stderr=sys.stderr
+                )
+
+                result = dst_fp.read()
+
+        template_body_dict = json.loads(result)
+        template = CloudFormationTemplate(template_body_dict, template.name)
+        return template

--- a/src/main/python/cfn_sphere/template/template_handler.py
+++ b/src/main/python/cfn_sphere/template/template_handler.py
@@ -1,11 +1,14 @@
 from cfn_sphere.file_loader import FileLoader
+from cfn_sphere.template.sam_packager import CloudFormationSamPackager
 from cfn_sphere.template.transformer import CloudFormationTemplateTransformer
 from cfn_sphere.util import get_git_repository_remote_url
 
 
 class TemplateHandler(object):
     @staticmethod
-    def get_template(template_url, working_dir):
+    def get_template(template_url, working_dir, region, package_bucket):
         template = FileLoader.get_cloudformation_template(template_url, working_dir)
         additional_stack_description = "Config repo url: {0}".format(get_git_repository_remote_url(working_dir))
-        return CloudFormationTemplateTransformer.transform_template(template, additional_stack_description)
+        template = CloudFormationTemplateTransformer.transform_template(template, additional_stack_description)
+        template = CloudFormationSamPackager.package(template_url, working_dir, template, region, package_bucket)
+        return template

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -221,7 +221,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -249,7 +249,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -278,7 +278,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -307,7 +307,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             OnFailure='DO_NOTHING',
             Parameters=[('a', 'b')],
             StackName='stack-name',
@@ -337,7 +337,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             OnFailure='DO_NOTHING',
             DisableRollback=True,
             Parameters=[('a', 'b')],
@@ -367,7 +367,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -393,7 +393,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -420,7 +420,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],

--- a/src/unittest/python/template/template_handler_tests.py
+++ b/src/unittest/python/template/template_handler_tests.py
@@ -21,7 +21,7 @@ class TemplateHandlerTests(TestCase):
         file_loader_mock.get_cloudformation_template.return_value = template
         get_git_repository_remote_url_mock.return_value = "my-repository-url"
 
-        TemplateHandler.get_template("my-template-url", "my-working-directory")
+        TemplateHandler.get_template("my-template-url", "my-working-directory", "eu-west-1", package_bucket=None)
 
         file_loader_mock.get_cloudformation_template.assert_called_once_with("my-template-url", "my-working-directory")
         get_git_repository_remote_url_mock.assert_called_once_with("my-working-directory")


### PR DESCRIPTION
Add SAM support to CloudFormation templates. If a stack config has the `package-bucket` attribute, `aws cloudformation package` will be called to upload artifacts to the given location.

Example stack config:

```yaml
region: eu-west-1
package-bucket: my-artifacts # New config value
stacks:
    stTestSam-AppTest1:
        # Package bucket can also be overridden per stack, e.g:
        # package-bucket: my-apptest1-artifacts
        template-url: apps/test1/template.yaml
```

`apps/test1` is a basic SAM app created with `sam init -o apps -n test1`