### PR TITLE
AWS-393: Add sam-build config option

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-square - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-square AWS CloudFormation management cli'
 url = 'https://github.com/KCOM-Enterprise/cfn-square'
-version = '0.2.8'
+version = '0.2.9'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -57,8 +57,7 @@ class StackActionHandler(object):
             else:
                 stack_policy = None
 
-            template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir,
-                                                    self.config.region, stack_config.package_bucket)
+            template = TemplateHandler.get_template(self.config, stack_config)
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config, self.cli_parameters)
 
             stack = CloudFormationStack(template=template,
@@ -95,8 +94,7 @@ class StackActionHandler(object):
             else:
                 stack_policy = None
 
-            template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir,
-                                                    self.config.region, stack_config.package_bucket)
+            template = TemplateHandler.get_template(self.config, stack_config)
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config, self.cli_parameters)
 
             stack = CloudFormationStack(template=template,

--- a/src/main/python/cfn_sphere/template/sam_packager.py
+++ b/src/main/python/cfn_sphere/template/sam_packager.py
@@ -16,13 +16,13 @@ class CloudFormationSamPackager:
     """
 
     @classmethod
-    def package(cls, template_url, working_dir, template, region, package_bucket):
+    def package(cls, template, config, stack_config):
         logger = get_logger()
 
-        if not package_bucket:
+        if not stack_config.package_bucket:
             return template
 
-        if template_url.lower().startswith("s3://") or  template_url.lower().startswith("https://"):
+        if stack_config.template_url.lower().startswith(("s3://", "https://")):
             raise Exception("SAM packaging is only supported for local templates (not S3/HTTPS)")
 
         template_body_dict = template.get_template_body_dict()
@@ -31,31 +31,62 @@ class CloudFormationSamPackager:
         # directory. Call `aws cloudformation package` to upload artifacts
         # to S3.
         aws_credentials = boto3.DEFAULT_SESSION.get_credentials()
-        with tempfile.NamedTemporaryFile(mode="w",
-                                         dir=os.path.dirname(os.path.join(working_dir, template_url)),
-                                         suffix=".json") as src_fp:
+        template_path = os.path.dirname(os.path.join(stack_config.working_dir, stack_config.template_url))
+        with tempfile.NamedTemporaryFile(mode="w", dir=template_path, suffix=".json") as src_fp:
             # Save the template. Ensure the buffer's flushed to disk before
             # calling `aws cloudformation package`.
             json.dump(template_body_dict, src_fp)
             src_fp.flush()
+            
+            src_template_filename = src_fp.name
+
+            # Call `sam build` if option is present in config.
+            if stack_config.sam_build not in (None, False):
+                logger.info("Building {}".format(stack_config.template_url))
+
+                build_path = tempfile.mkdtemp()
+
+                args = [
+                    "sam",
+                    "build",
+                    "--template", src_template_filename,
+                    "--build-dir", build_path
+                ]
+                if stack_config.sam_build is not True:
+                    args += list(stack_config.sam_build)
+
+                subprocess.check_call(
+                    args=args,
+                    env=dict(
+                        os.environ,
+                        AWS_REGION=config.region,
+                        AWS_ACCESS_KEY_ID=aws_credentials.access_key,
+                        AWS_SECRET_ACCESS_KEY=aws_credentials.secret_key,
+                        AWS_SESSION_TOKEN=aws_credentials.token
+                    ),
+                    stdout=sys.stdout,
+                    stderr=sys.stderr
+                )
+
+                src_template_filename = os.path.join(build_path, "template.yaml")
 
             # Open temporary file for the packaged template.
             # We'd previously used stdout, but the packaging process also
             # wrote status to stdout when the source artifact changed, causing
             # malformed JSON.
             with tempfile.NamedTemporaryFile(mode="r") as dst_fp:
-                logger.info("Packaging {}".format(template_url))
-                result = subprocess.check_call(
+                logger.info("Packaging {}".format(stack_config.template_url))
+                subprocess.check_call(
                     args=[
                         "aws", "cloudformation", "package",
-                        "--template-file", src_fp.name,
-                        "--s3-bucket", package_bucket,
+                        "--template-file", src_template_filename,
+                        "--s3-bucket", stack_config.package_bucket,
                         "--output-template-file", dst_fp.name,
                         "--use-json"
                     ],
                     env=dict(
                         os.environ,
-                        AWS_REGION=region,
+                        AWS_REGION=config.region,
                         AWS_ACCESS_KEY_ID=aws_credentials.access_key,
                         AWS_SECRET_ACCESS_KEY=aws_credentials.secret_key,
                         AWS_SESSION_TOKEN=aws_credentials.token

--- a/src/main/python/cfn_sphere/template/template_handler.py
+++ b/src/main/python/cfn_sphere/template/template_handler.py
@@ -6,9 +6,21 @@ from cfn_sphere.util import get_git_repository_remote_url
 
 class TemplateHandler(object):
     @staticmethod
-    def get_template(template_url, working_dir, region, package_bucket):
-        template = FileLoader.get_cloudformation_template(template_url, working_dir)
-        additional_stack_description = "Config repo url: {0}".format(get_git_repository_remote_url(working_dir))
-        template = CloudFormationTemplateTransformer.transform_template(template, additional_stack_description)
-        template = CloudFormationSamPackager.package(template_url, working_dir, template, region, package_bucket)
+    def get_template(config, stack_config):
+        template = FileLoader.get_cloudformation_template(
+            stack_config.template_url,
+            stack_config.working_dir
+        )
+        additional_stack_description = "Config repo url: {0}".format(
+            get_git_repository_remote_url(stack_config.working_dir)
+        )
+        template = CloudFormationTemplateTransformer.transform_template(
+            template,
+            additional_stack_description
+        )
+        template = CloudFormationSamPackager.package(
+            template,
+            config,
+            stack_config
+        )
         return template

--- a/src/unittest/python/template/template_handler_tests.py
+++ b/src/unittest/python/template/template_handler_tests.py
@@ -17,11 +17,25 @@ class TemplateHandlerTests(TestCase):
     @patch("cfn_sphere.template.template_handler.get_git_repository_remote_url")
     def test_get_template_calls_file_handler(self, get_git_repository_remote_url_mock, template_transformer_mock,
                                              file_loader_mock):
+        class MockConfig:
+            pass
+
+        class MockStackConfig:
+            pass
+
+        config = MockConfig()
+        config.region = "eu-west-1"
+
+        stack_config = MockStackConfig()
+        stack_config.template_url = "my-template-url"
+        stack_config.working_dir = "my-working-directory"
+        stack_config.package_bucket = None
+
         template = CloudFormationTemplate({}, "my-template")
         file_loader_mock.get_cloudformation_template.return_value = template
         get_git_repository_remote_url_mock.return_value = "my-repository-url"
 
-        TemplateHandler.get_template("my-template-url", "my-working-directory", "eu-west-1", package_bucket=None)
+        TemplateHandler.get_template(config, stack_config)
 
         file_loader_mock.get_cloudformation_template.assert_called_once_with("my-template-url", "my-working-directory")
         get_git_repository_remote_url_mock.assert_called_once_with("my-working-directory")


### PR DESCRIPTION
Adds a `sam-build` config option so SAM apps can use external dependencies - e.g installing PyPI packages for Python apps.

The `sam-build` option can be placed at the top-level of a config file or within a particular stack's config. Allowed values are:

 * `false`: Default. Disable SAM builds.
 * `true`: Enable SAM builds.
 * `["list", "of", "strings"]`: Enable SAM builds and pass the given options to the `sam build` command. `["--use-container"]` is handy - it runs a virtual Lambda environment in Docker, essential when building binary dependencies.