### PR TITLE
AWS-394: Default session token

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-square - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-square AWS CloudFormation management cli'
 url = 'https://github.com/KCOM-Enterprise/cfn-square'
-version = '0.2.8'
+version = '0.2.9'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/main/python/cfn_sphere/template/sam_packager.py
+++ b/src/main/python/cfn_sphere/template/sam_packager.py
@@ -58,7 +58,7 @@ class CloudFormationSamPackager:
                         AWS_REGION=region,
                         AWS_ACCESS_KEY_ID=aws_credentials.access_key,
                         AWS_SECRET_ACCESS_KEY=aws_credentials.secret_key,
-                        AWS_SESSION_TOKEN=aws_credentials.token
+                        AWS_SESSION_TOKEN=aws_credentials.token or ''
                     ),
                     stdout=subprocess.DEVNULL,
                     stderr=sys.stderr


### PR DESCRIPTION
Minor update to version 0.2.8 to prevent fail on no session token available